### PR TITLE
Update reqs version of MarkupSafe

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -80,7 +80,7 @@ description = "Safely add untrusted strings to HTML/XML markup."
 name = "markupsafe"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
-version = "1.1.1"
+version = "2.0.1"
 
 [[package]]
 category = "dev"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.6"
 wtforms = "^2.3.3"
-markupsafe = "^1.1.1"
+markupsafe = "^2.0.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/wtforms_hcaptcha/widgets.py
+++ b/wtforms_hcaptcha/widgets.py
@@ -3,7 +3,7 @@
 from markupsafe import Markup
 
 HCAPTCHA_HTML = Markup("""<div class="h-captcha" data-sitekey="{site_key}"></div>
-<script defer src="https://hcaptcha.com/1/api.js" async defer></script>
+<script src="https://hcaptcha.com/1/api.js" async defer></script>
 """)
 
 

--- a/wtforms_hcaptcha/widgets.py
+++ b/wtforms_hcaptcha/widgets.py
@@ -3,7 +3,7 @@
 from markupsafe import Markup
 
 HCAPTCHA_HTML = Markup("""<div class="h-captcha" data-sitekey="{site_key}"></div>
-<script src="https://hcaptcha.com/1/api.js" async defer></script>
+<script defer src="https://hcaptcha.com/1/api.js" async defer></script>
 """)
 
 


### PR DESCRIPTION
Update reqs version of MarkupSafe because jinja2 3.0.1 depends on MarkupSafe>=2.0